### PR TITLE
Update membership_agreement.md

### DIFF
--- a/membership_agreement.md
+++ b/membership_agreement.md
@@ -6,7 +6,7 @@
 
 #### As a member of the cooperative I am entitled to:
 
-- Have one vote at general and other co-op meetings and receive proper notice of meetings
+- Have one membership vote in all Aragon Cooperative DAO votes
 
 - Serve in working groups
 
@@ -16,20 +16,18 @@
 
 - Receive information about the cooperative’s financial status and other important processes or decision (e.g. resolutions). 
 
-- Receive dividends on shares held in the cooperative
-
 
 ### Responsibilities as a member of the cooperative
 
 #### As a member of the cooperative I have a responsibility to:
 
-- Participate in the governance of the cooperative through attendance of general meeting, voting on decisions, asking questions, and participating in working groups
+- Participate in the governance of the cooperative through voting in the Aragon Cooperative DAO, asking questions, and participating in working groups
 
 - Support the mission, vision, and goals of the cooperative
 
 - Adhere to the policies and procedures of the cooperative set out in the organizational documents and created by the board
 
-- Support the cooperative’s operations by contributing to the delivery of services
+- Support the cooperative’s operations by contributing to the delivery of the Aragon Cooperative's goals
 
 - Learn more about the cooperative’s operations and organizational capacity  
 


### PR DESCRIPTION
As always, not attached to these edits, but figured a PR might save us more time than just creating an Issue with comments. 

<br>

### Rights as a member of the cooperative
- changed the initial line to remove any mention of meetings since we make decisions via the DAO, not via meetings.
- removed talk of "dividends" because that's treacherous territory. Also, the Cooperative isn't setup like that so we don't want to set false expectations. 
- not sure about the financial status thing because everything in on-chain by default, but I guess it doesn't hurt to throw that in there lol

### Responsibilities as a member of the cooperative
- removed the reference to meetings because decisions are made via the DAO and historically meetings have had minimal turnout and net negative impact
- changed delivery of services to "goals" because that seems more actionable and in line with our current process of voting on stuff to be done and then doing it

### Obligations of the cooperative to members

Looks good! 


### How do members sign this document?
- They can sign it the same way they sign their Ethereum addresses using the Keybase PGP thing? It's a little clunky, but I think the effort required will help filter out members who want to participate vs those who don't want to be bothered. Plus it'll create a verifiable record that people have read and signed the membership agreement and know what is expected of them. No excuses.